### PR TITLE
Rename step to install dependencies and update command to use 'uv sync'

### DIFF
--- a/.github/actions/setup-python-core/action.yml
+++ b/.github/actions/setup-python-core/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ".python-version"
-    - name: Create virtual environment
+    - name: Install dependencies
       run: |
-        uv venv
+        uv sync
       shell: bash


### PR DESCRIPTION
This pull request updates the workflow in `.github/actions/setup-python-core/action.yml` to improve dependency management by switching from creating a virtual environment to directly installing dependencies.

Dependency management update:

* Replaced the step that created a virtual environment (`uv venv`) with a step that installs dependencies using `uv sync` in the workflow file `.github/actions/setup-python-core/action.yml`.