### PR TITLE
Add another ci action

### DIFF
--- a/.github/actions/ci/version-check/action.yml
+++ b/.github/actions/ci/version-check/action.yml
@@ -16,13 +16,13 @@ runs:
       - name: Check version consistency
         run: |
           # Get reference version from pyproject.toml
-          REFERENCE_VERSION=$(uv run ci-version-pyproject)
+          REFERENCE_VERSION=$(uv run ci-pyproject-version)
           echo "Reference version (pyproject.toml): $REFERENCE_VERSION"
 
           MISMATCH=false
 
           # Check uv.lock
-          LOCK_VERSION=$(uv run ci-version-uv-lock)
+          LOCK_VERSION=$(uv run ci-uv-lock-version)
           if [ "$LOCK_VERSION" != "$REFERENCE_VERSION" ]; then
             echo "❌ uv.lock: $LOCK_VERSION (expected $REFERENCE_VERSION)"
             MISMATCH=true

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -167,8 +167,8 @@ steps:
 - Location: `version-check/action.yml`
 - Steps:
   - Uses the `install-python-dev` action
-  - Extracts version from `pyproject.toml` using `uv run ci-version-pyproject`
-  - Verifies `uv.lock` version matches using `uv run ci-version-uv-lock`
+  - Extracts version from `pyproject.toml` using `uv run ci-pyproject-version`
+  - Verifies `uv.lock` version matches using `uv run ci-uv-lock-version`
   - Optionally checks additional version files via `additional-versions` input
   - Fails if any version mismatch is detected
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ repository = "https://github.com/javidahmed64592/template-python"
 
 [project.scripts]
 ci-pyproject-version = "template_python.workflows:print_version_pyproject"
+ci-pyproject-name = "template_python.workflows:print_name_pyproject"
 ci-uv-lock-version = "template_python.workflows:print_version_uv_lock"
 example-entrypoint = "template_python.main:example_function"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dev = [
 repository = "https://github.com/javidahmed64592/template-python"
 
 [project.scripts]
-ci-version-pyproject = "template_python.workflows:print_version_pyproject"
-ci-version-uv-lock = "template_python.workflows:print_version_uv_lock"
+ci-pyproject-version = "template_python.workflows:print_version_pyproject"
+ci-uv-lock-version = "template_python.workflows:print_version_uv_lock"
 example-entrypoint = "template_python.main:example_function"
 
 [tool.hatch.metadata]

--- a/template_python/workflows.py
+++ b/template_python/workflows.py
@@ -28,20 +28,32 @@ def _get_version_pyproject() -> str:
 
 
 @cache
+def _get_name_pyproject() -> str:
+    """Get the name from pyproject.toml."""
+    pyproject = _load_pyproject()
+    return str(pyproject["project"]["name"])
+
+
+@cache
 def _get_version_uv_lock() -> str:
     """Get the version from uv.lock."""
-    pyproject = _load_pyproject()
+    name = _get_name_pyproject()
     uv_lock = _load_uv_lock()
-    if pkg := next((p for p in uv_lock["package"] if p["name"] == pyproject["project"]["name"]), None):
+    if pkg := next((p for p in uv_lock["package"] if p["name"] == name), None):
         return str(pkg["version"])
 
-    error_msg = f"Package '{pyproject['project']['name']}' not found in uv.lock"
+    error_msg = f"Package '{name}' not found in uv.lock"
     raise ValueError(error_msg)
 
 
 def print_version_pyproject() -> None:
     """Get the version from pyproject.toml."""
     print(_get_version_pyproject())
+
+
+def print_name_pyproject() -> None:
+    """Get the name from pyproject.toml."""
+    print(_get_name_pyproject())
 
 
 def print_version_uv_lock() -> None:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5,10 +5,12 @@ from unittest.mock import patch
 import pytest
 
 from template_python.workflows import (
+    _get_name_pyproject,
     _get_version_pyproject,
     _get_version_uv_lock,
     _load_pyproject,
     _load_uv_lock,
+    print_name_pyproject,
     print_version_pyproject,
     print_version_uv_lock,
 )
@@ -26,15 +28,20 @@ class TestWorkflows:
 
     def test_load_uv_lock(self) -> None:
         """Test loading the uv.lock file."""
-        pyproject = _load_pyproject()
+        name = _get_name_pyproject()
         uv_lock = _load_uv_lock()
         assert "package" in uv_lock
-        assert any(p["name"] == pyproject["project"]["name"] for p in uv_lock["package"])
+        assert any(p["name"] == name for p in uv_lock["package"])
 
     def test_get_version_pyproject(self) -> None:
         """Test getting the version from pyproject.toml."""
         version = _get_version_pyproject()
         assert isinstance(version, str)
+
+    def test_get_name_pyproject(self) -> None:
+        """Test getting the name from pyproject.toml."""
+        name = _get_name_pyproject()
+        assert isinstance(name, str)
 
     def test_get_version_uv_lock(self) -> None:
         """Test getting the version from uv.lock."""
@@ -56,6 +63,10 @@ class TestWorkflows:
     def test_print_version_pyproject(self) -> None:
         """Test printing the version from pyproject.toml."""
         print_version_pyproject()
+
+    def test_print_name_pyproject(self) -> None:
+        """Test printing the name from pyproject.toml."""
+        print_name_pyproject()
 
     def test_print_version_uv_lock(self) -> None:
         """Test printing the version from uv.lock."""

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ requires-dist = [
     { name = "pyhere", specifier = ">=1.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.4" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.5" },
     { name = "validate-pyproject", marker = "extra == 'dev'", specifier = ">=0.25.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
This pull request refactors the workflow scripts and related documentation to improve consistency and clarity in version and name extraction from `pyproject.toml` and `uv.lock`. The main changes include renaming script entrypoints for clarity, adding new functionality to extract the project name, updating the workflow logic and documentation, and extending the test suite to cover these updates.

**Workflow and script refactoring:**

* Renamed script entrypoints in `pyproject.toml` for extracting version and name to use a consistent naming scheme (`ci-pyproject-version`, `ci-pyproject-name`, `ci-uv-lock-version`) and added a new entrypoint for extracting the project name.

**Functionality improvements:**

* Added `_get_name_pyproject` and `print_name_pyproject` functions in `template_python/workflows.py` to extract and print the project name from `pyproject.toml`, and updated `_get_version_uv_lock` to use the new name extraction method for improved reliability. [[1]](diffhunk://#diff-ea6ec9d30bd039a01ba224b519cd5fb4027e7dcdaa6a4581d635a4bbbc06e79dR30-R45) [[2]](diffhunk://#diff-ea6ec9d30bd039a01ba224b519cd5fb4027e7dcdaa6a4581d635a4bbbc06e79dR54-R58)

**Workflow logic and documentation updates:**

* Updated the CI workflow in `.github/actions/ci/version-check/action.yml` and its documentation in `docs/WORKFLOWS.md` to use the new script names for extracting version information. [[1]](diffhunk://#diff-f7e6e6268b0d81dc1741c1e5b4df691cf31c9f83c7386d26334f6b52be438fe8L19-R25) [[2]](diffhunk://#diff-ed9b8f4a4f6633f84a0d372314788cf32c9dac97a3753a915b9a848ebc14c4cfL170-R171)

**Testing enhancements:**

* Added and updated tests in `tests/test_workflows.py` to cover the new name extraction functionality and ensure that the workflow logic is properly validated. [[1]](diffhunk://#diff-062d7920c867ef17e231797ab56a990f96a5beafa69c52c03fee3f19f7b19cccR8-R13) [[2]](diffhunk://#diff-062d7920c867ef17e231797ab56a990f96a5beafa69c52c03fee3f19f7b19cccL29-R45) [[3]](diffhunk://#diff-062d7920c867ef17e231797ab56a990f96a5beafa69c52c03fee3f19f7b19cccR67-R70)