### PR TITLE
Update action versions

### DIFF
--- a/.github/actions/build/build-wheel/action.yml
+++ b/.github/actions/build/build-wheel/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/setup/install-python-core@main
+      - uses: ./.github/actions/setup/install-python-core@main
 
       - name: Create wheel
         run: |

--- a/.github/actions/build/build-wheel/action.yml
+++ b/.github/actions/build/build-wheel/action.yml
@@ -4,7 +4,7 @@ description: Build Python wheel package and upload as artifact.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-core@main
 
       - name: Create wheel
@@ -19,7 +19,7 @@ runs:
         shell: bash
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}_wheel
           path: dist/${{ env.PACKAGE_NAME }}-*-py3-none-any.whl

--- a/.github/actions/build/verify-structure/action.yml
+++ b/.github/actions/build/verify-structure/action.yml
@@ -4,11 +4,11 @@ description: Download and verify the structure of the built wheel package.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-core@main
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}_wheel
 

--- a/.github/actions/build/verify-structure/action.yml
+++ b/.github/actions/build/verify-structure/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/setup/install-python-core@main
+      - uses: ./.github/actions/setup/install-python-core@main
 
       - name: Download wheel artifact
         uses: actions/download-artifact@v7

--- a/.github/actions/ci/bandit/action.yml
+++ b/.github/actions/ci/bandit/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev@main
 
       - name: Security check
         run: |

--- a/.github/actions/ci/bandit/action.yml
+++ b/.github/actions/ci/bandit/action.yml
@@ -4,7 +4,7 @@ description: Run Bandit security checks on the codebase.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
 
       - name: Security check
@@ -12,7 +12,7 @@ runs:
           uv run bandit -r ${{ env.PACKAGE_NAME }} -f json -o bandit-report.json || true
         shell: bash
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: bandit-report
           path: bandit-report.json

--- a/.github/actions/ci/mypy/action.yml
+++ b/.github/actions/ci/mypy/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev@main
 
       - name: Check with mypy
         run: |

--- a/.github/actions/ci/mypy/action.yml
+++ b/.github/actions/ci/mypy/action.yml
@@ -4,7 +4,7 @@ description: Run Mypy type checking on the codebase.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
 
       - name: Check with mypy

--- a/.github/actions/ci/pip-audit/action.yml
+++ b/.github/actions/ci/pip-audit/action.yml
@@ -4,7 +4,7 @@ description: Run pip-audit to check for known vulnerabilities in dependencies.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
 
       - name: Audit dependencies

--- a/.github/actions/ci/pip-audit/action.yml
+++ b/.github/actions/ci/pip-audit/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev@main
 
       - name: Audit dependencies
         run: |

--- a/.github/actions/ci/pytest/action.yml
+++ b/.github/actions/ci/pytest/action.yml
@@ -4,7 +4,7 @@ description: Run Pytest tests with coverage reporting.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
 
       - name: Test with pytest
@@ -13,7 +13,7 @@ runs:
         shell: bash
 
       - name: Upload backend coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: backend-coverage-report
           path: htmlcov

--- a/.github/actions/ci/pytest/action.yml
+++ b/.github/actions/ci/pytest/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev@main
 
       - name: Test with pytest
         run: |

--- a/.github/actions/ci/ruff/action.yml
+++ b/.github/actions/ci/ruff/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev@main
 
       - name: Check with ruff
         run: |

--- a/.github/actions/ci/ruff/action.yml
+++ b/.github/actions/ci/ruff/action.yml
@@ -4,7 +4,7 @@ description: Run Ruff linting checks on the codebase.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
 
       - name: Check with ruff

--- a/.github/actions/ci/validate-pyproject/action.yml
+++ b/.github/actions/ci/validate-pyproject/action.yml
@@ -4,7 +4,7 @@ description: Validate pyproject.toml structure.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
 
       - name: Validate pyproject.toml

--- a/.github/actions/ci/validate-pyproject/action.yml
+++ b/.github/actions/ci/validate-pyproject/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev@main
 
       - name: Validate pyproject.toml
         run: |

--- a/.github/actions/ci/version-check/action.yml
+++ b/.github/actions/ci/version-check/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
 
       - name: Check version consistency

--- a/.github/actions/ci/version-check/action.yml
+++ b/.github/actions/ci/version-check/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev@main
 
       - name: Check version consistency
         run: |

--- a/.github/actions/setup/install-python-core/action.yml
+++ b/.github/actions/setup/install-python-core/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v6
-    - uses: javidahmed64592/template-python/.github/actions/setup/setup-uv-python@main
+    - uses: ./.github/actions/setup/setup-uv-python@main
 
     - name: Install dependencies
       run: |

--- a/.github/actions/setup/install-python-core/action.yml
+++ b/.github/actions/setup/install-python-core/action.yml
@@ -4,7 +4,7 @@ description: Installs core Python dependencies from pyproject.toml using uv.
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: javidahmed64592/template-python/.github/actions/setup/setup-uv-python@main
 
     - name: Install dependencies

--- a/.github/actions/setup/install-python-dev/action.yml
+++ b/.github/actions/setup/install-python-dev/action.yml
@@ -4,7 +4,7 @@ description: Installs dev Python dependencies from pyproject.toml using uv.
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: javidahmed64592/template-python/.github/actions/setup/setup-uv-python@main
 
     - name: Install dependencies

--- a/.github/actions/setup/install-python-dev/action.yml
+++ b/.github/actions/setup/install-python-dev/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v6
-    - uses: javidahmed64592/template-python/.github/actions/setup/setup-uv-python@main
+    - uses: ./.github/actions/setup/setup-uv-python@main
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
   build-wheel:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/build/build-wheel@main
 
   verify-structure:
     runs-on: ubuntu-latest
     needs: build-wheel
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/build/verify-structure@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/build/build-wheel@main
+      - uses: ./.github/actions/build/build-wheel@main
 
   verify-structure:
     runs-on: ubuntu-latest
     needs: build-wheel
     steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/build/verify-structure@main
+      - uses: ./.github/actions/build/verify-structure@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,41 +15,41 @@ jobs:
   validate-pyproject:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/ci/validate-pyproject@main
 
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/ci/ruff@main
 
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/ci/mypy@main
 
   pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/ci/pytest@main
 
   bandit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/ci/bandit@main
 
   pip-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/ci/pip-audit@main
 
   version-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: javidahmed64592/template-python/.github/actions/ci/version-check@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,40 +16,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/ci/validate-pyproject@main
+      - uses: ./.github/actions/ci/validate-pyproject@main
 
   ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/ci/ruff@main
+      - uses: ./.github/actions/ci/ruff@main
 
   mypy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/ci/mypy@main
+      - uses: ./.github/actions/ci/mypy@main
 
   pytest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/ci/pytest@main
+      - uses: ./.github/actions/ci/pytest@main
 
   bandit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/ci/bandit@main
+      - uses: ./.github/actions/ci/bandit@main
 
   pip-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/ci/pip-audit@main
+      - uses: ./.github/actions/ci/pip-audit@main
 
   version-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: javidahmed64592/template-python/.github/actions/ci/version-check@main
+      - uses: ./.github/actions/ci/version-check@main

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -24,7 +24,7 @@ The following actions can be referenced from other repositories using `javidahme
 - Location: `setup-uv-python/action.yml`
 - Steps:
   - Installs uv using `astral-sh/setup-uv@v7` with caching enabled
-  - Sets up Python using the version specified in `.python-version`
+  - Sets up Python using `actions/setup-python@v6` and the version specified in `.python-version`
   - Caches dependencies based on `uv.lock` for faster builds
 
 Usage:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows and custom composite actions to use local action references and newer versions of key actions, improving maintainability and ensuring the use of up-to-date tooling. The changes also remove dependencies on external template repositories, making the workflow definitions fully self-contained.

**Workflow and action reference updates:**

* Updated all workflow steps in `.github/workflows/build.yml` and `.github/workflows/ci.yml` to use local custom actions (e.g., `./.github/actions/...`) instead of referencing `javidahmed64592/template-python`, and bumped `actions/checkout` from v4 to v6. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L18-R26) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL18-R55)
* Updated all composite actions in `.github/actions/` to use local setup actions and newer versions of `actions/checkout` and related actions (v6 or v7), replacing previous external references. [[1]](diffhunk://#diff-f65ceb4aa896a48109c0f158a6dcea220f9ff876f878f9f4108e22d4363d10e3L7-R8) [[2]](diffhunk://#diff-bd52ab90a0a08f216430880f6229c55c9cce1a60a5fd113c7bb08980a030748dL7-R11) [[3]](diffhunk://#diff-7dd4679fbcd0361c01825a7581078219358278b1ba7c6e5871843e34d076e48cL7-R15) [[4]](diffhunk://#diff-e839be1fb2c84ebde8f1cb88ffed3eb71510daa6fdb7cbff346fed18a4e3a0a9L7-R8) [[5]](diffhunk://#diff-712f0fe4f82fa6245233e51f17e139a243230bf1fb773c95a2dbf991d1f2a861L7-R8) [[6]](diffhunk://#diff-00ad0a661817fe7867276cf46198da0e94761a94060da856a057a7a432995cd9L7-R16) [[7]](diffhunk://#diff-a2fc2029ef04a6348257eb8ae5e42b673171470cf0b6e98b6223c6f86afd7da3L7-R8) [[8]](diffhunk://#diff-ae0e40b806ed62d8ee33315d8e967f02be265483820cf2807a7e2122b119c7e2L7-R8) [[9]](diffhunk://#diff-f7e6e6268b0d81dc1741c1e5b4df691cf31c9f83c7386d26334f6b52be438fe8L13-R14) [[10]](diffhunk://#diff-bf0eb66e60adb3a2cf9c9070168ea1952d34385123f03e43a8474a4dc7d40cbbL7-R8) [[11]](diffhunk://#diff-3f44307bf777f419b8da80c4aeb4e049b23f38a36a68c0b8af010eb9983f9201L7-R8)
* Upgraded artifact upload and download steps to use `actions/upload-artifact@v7` and `actions/download-artifact@v7` for improved performance and reliability. [[1]](diffhunk://#diff-f65ceb4aa896a48109c0f158a6dcea220f9ff876f878f9f4108e22d4363d10e3L22-R22) [[2]](diffhunk://#diff-bd52ab90a0a08f216430880f6229c55c9cce1a60a5fd113c7bb08980a030748dL7-R11) [[3]](diffhunk://#diff-7dd4679fbcd0361c01825a7581078219358278b1ba7c6e5871843e34d076e48cL7-R15) [[4]](diffhunk://#diff-00ad0a661817fe7867276cf46198da0e94761a94060da856a057a7a432995cd9L7-R16)
* Updated documentation in `docs/WORKFLOWS.md` to reflect the use of `actions/setup-python@v6` for Python setup and local action references.

These changes make the CI/CD pipeline more robust and easier to maintain by relying on local actions and the latest supported versions of GitHub Actions.