### PR TITLE
Update action references to remove explicit versioning for consistency

### DIFF
--- a/.github/actions/build/build-wheel/action.yml
+++ b/.github/actions/build/build-wheel/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup/install-python-core@main
+      - uses: ./.github/actions/setup/install-python-core
 
       - name: Create wheel
         run: |

--- a/.github/actions/build/verify-structure/action.yml
+++ b/.github/actions/build/verify-structure/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup/install-python-core@main
+      - uses: ./.github/actions/setup/install-python-core
 
       - name: Download wheel artifact
         uses: actions/download-artifact@v7

--- a/.github/actions/ci/bandit/action.yml
+++ b/.github/actions/ci/bandit/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev
 
       - name: Security check
         run: |

--- a/.github/actions/ci/mypy/action.yml
+++ b/.github/actions/ci/mypy/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev
 
       - name: Check with mypy
         run: |

--- a/.github/actions/ci/pip-audit/action.yml
+++ b/.github/actions/ci/pip-audit/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev
 
       - name: Audit dependencies
         run: |

--- a/.github/actions/ci/pytest/action.yml
+++ b/.github/actions/ci/pytest/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev
 
       - name: Test with pytest
         run: |

--- a/.github/actions/ci/ruff/action.yml
+++ b/.github/actions/ci/ruff/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev
 
       - name: Check with ruff
         run: |

--- a/.github/actions/ci/validate-pyproject/action.yml
+++ b/.github/actions/ci/validate-pyproject/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev
 
       - name: Validate pyproject.toml
         run: |

--- a/.github/actions/ci/version-check/action.yml
+++ b/.github/actions/ci/version-check/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup/install-python-dev@main
+      - uses: ./.github/actions/setup/install-python-dev
 
       - name: Check version consistency
         run: |

--- a/.github/actions/setup/install-python-core/action.yml
+++ b/.github/actions/setup/install-python-core/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v6
-    - uses: ./.github/actions/setup/setup-uv-python@main
+    - uses: ./.github/actions/setup/setup-uv-python
 
     - name: Install dependencies
       run: |

--- a/.github/actions/setup/install-python-dev/action.yml
+++ b/.github/actions/setup/install-python-dev/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v6
-    - uses: ./.github/actions/setup/setup-uv-python@main
+    - uses: ./.github/actions/setup/setup-uv-python
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/build/build-wheel@main
+      - uses: ./.github/actions/build/build-wheel
 
   verify-structure:
     runs-on: ubuntu-latest
     needs: build-wheel
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/build/verify-structure@main
+      - uses: ./.github/actions/build/verify-structure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,40 +16,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/ci/validate-pyproject@main
+      - uses: ./.github/actions/ci/validate-pyproject
 
   ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/ci/ruff@main
+      - uses: ./.github/actions/ci/ruff
 
   mypy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/ci/mypy@main
+      - uses: ./.github/actions/ci/mypy
 
   pytest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/ci/pytest@main
+      - uses: ./.github/actions/ci/pytest
 
   bandit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/ci/bandit@main
+      - uses: ./.github/actions/ci/bandit
 
   pip-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/ci/pip-audit@main
+      - uses: ./.github/actions/ci/pip-audit
 
   version-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/ci/version-check@main
+      - uses: ./.github/actions/ci/version-check


### PR DESCRIPTION
This pull request updates all references to custom GitHub Actions in workflow and action files by removing the explicit `@main` branch specifier. This change makes the workflows use the default branch for each action, simplifying maintenance and ensuring consistency as the default branch evolves.

Updates to workflow job steps:

* All custom action usages in `.github/workflows/build.yml` and `.github/workflows/ci.yml` have been changed to omit the `@main` tag, so they now reference the default branch for each action. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L19-R26) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL19-R55)

Updates to composite action steps:

* In all custom composite actions under `.github/actions/build/`, `.github/actions/ci/`, and `.github/actions/setup/`, references to other local actions now omit `@main`, ensuring consistency and easier future updates. [[1]](diffhunk://#diff-f65ceb4aa896a48109c0f158a6dcea220f9ff876f878f9f4108e22d4363d10e3L8-R8) [[2]](diffhunk://#diff-bd52ab90a0a08f216430880f6229c55c9cce1a60a5fd113c7bb08980a030748dL8-R8) [[3]](diffhunk://#diff-7dd4679fbcd0361c01825a7581078219358278b1ba7c6e5871843e34d076e48cL8-R8) [[4]](diffhunk://#diff-e839be1fb2c84ebde8f1cb88ffed3eb71510daa6fdb7cbff346fed18a4e3a0a9L8-R8) [[5]](diffhunk://#diff-712f0fe4f82fa6245233e51f17e139a243230bf1fb773c95a2dbf991d1f2a861L8-R8) [[6]](diffhunk://#diff-00ad0a661817fe7867276cf46198da0e94761a94060da856a057a7a432995cd9L8-R8) [[7]](diffhunk://#diff-a2fc2029ef04a6348257eb8ae5e42b673171470cf0b6e98b6223c6f86afd7da3L8-R8) [[8]](diffhunk://#diff-ae0e40b806ed62d8ee33315d8e967f02be265483820cf2807a7e2122b119c7e2L8-R8) [[9]](diffhunk://#diff-f7e6e6268b0d81dc1741c1e5b4df691cf31c9f83c7386d26334f6b52be438fe8L14-R14) [[10]](diffhunk://#diff-bf0eb66e60adb3a2cf9c9070168ea1952d34385123f03e43a8474a4dc7d40cbbL8-R8) [[11]](diffhunk://#diff-3f44307bf777f419b8da80c4aeb4e049b23f38a36a68c0b8af010eb9983f9201L8-R8)