### PR TITLE
Remove file verification from build action and update documentation

### DIFF
--- a/.github/actions/build/verify-structure/action.yml
+++ b/.github/actions/build/verify-structure/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: 'Newline-separated list of directories expected to exist relative to site-packages'
     required: false
     default: ''
-  expected-files:
-    description: 'Newline-separated list of files expected to exist relative to site-packages'
-    required: false
-    default: ''
 
 runs:
   using: composite
@@ -40,35 +36,22 @@ runs:
 
       - name: Verify installed package structure
         run: |
-          # Find site-packages directory
           SITE_PACKAGES=$(find . -name "site-packages" -type d | head -1)
           echo "Site-packages directory: $SITE_PACKAGES"
 
-          # Check for required directories in site-packages
+          # Check required directories in site-packages
           echo "Checking required directories in site-packages..."
-
           REQUIRED_DIRS=(
             "${SITE_PACKAGES}"
             "${SITE_PACKAGES}/${{ env.PACKAGE_NAME }}"
           )
-          REQUIRED_FILES=()
 
-          # Build array of required directories
           if [ -n "${{ inputs.expected-directories }}" ]; then
             while IFS= read -r dir; do
               if [ -n "$dir" ]; then
                 REQUIRED_DIRS+=("${SITE_PACKAGES}/${dir}")
               fi
             done <<< "${{ inputs.expected-directories }}"
-          fi
-
-          # Build array of required files
-          if [ -n "${{ inputs.expected-files }}" ]; then
-            while IFS= read -r file; do
-              if [ -n "$file" ]; then
-                REQUIRED_FILES+=("${SITE_PACKAGES}/${file}")
-              fi
-            done <<< "${{ inputs.expected-files }}"
           fi
 
           # Check for required directories in site-packages
@@ -79,15 +62,4 @@ runs:
               exit 1
             fi
           done
-
-          # Check for required files in site-packages
-          if [ ${#REQUIRED_FILES[@]} -gt 0 ]; then
-            echo "Checking required files in site-packages..."
-            for file in "${REQUIRED_FILES[@]}"; do
-              if [ ! -f "$file" ]; then
-                echo "Required file not found: $file"
-                exit 1
-              fi
-            done
-          fi
         shell: bash

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -213,8 +213,8 @@ steps:
   - Downloads the wheel artifact (named `{PACKAGE_NAME}_wheel`)
   - Installs the wheel using `uv pip install`
   - Verifies that `site-packages` and the package directory exist
-  - Optionally verifies additional directories and files specified in inputs
-  - Fails if any required structure is missing
+  - Optionally verifies additional directories specified in inputs
+  - Fails if any required directory is missing
 
 Usage:
 ```yaml
@@ -229,8 +229,6 @@ steps:
     with:
       expected-directories: |
         static
-      expected-files: |
-        static/index.html
 ```
 
 ## Workflows (`./github/workflows`)


### PR DESCRIPTION
This pull request simplifies the `verify-structure` GitHub Action by removing support for verifying required files and focusing solely on required directories. Documentation is updated to reflect this change, clarifying the inputs and expected behavior.

**Action workflow simplification:**

* Removed the `expected-files` input and all related logic for checking required files in `.github/actions/build/verify-structure/action.yml`, so the action now only checks for required directories. [[1]](diffhunk://#diff-bd52ab90a0a08f216430880f6229c55c9cce1a60a5fd113c7bb08980a030748dL9-L12) [[2]](diffhunk://#diff-bd52ab90a0a08f216430880f6229c55c9cce1a60a5fd113c7bb08980a030748dL43-L56) [[3]](diffhunk://#diff-bd52ab90a0a08f216430880f6229c55c9cce1a60a5fd113c7bb08980a030748dL65-L73) [[4]](diffhunk://#diff-bd52ab90a0a08f216430880f6229c55c9cce1a60a5fd113c7bb08980a030748dL82-L92)

**Documentation updates:**

* Updated `docs/WORKFLOWS.md` to remove references to verifying files, and clarified that only directories can be specified for verification. [[1]](diffhunk://#diff-ed9b8f4a4f6633f84a0d372314788cf32c9dac97a3753a915b9a848ebc14c4cfL216-R217) [[2]](diffhunk://#diff-ed9b8f4a4f6633f84a0d372314788cf32c9dac97a3753a915b9a848ebc14c4cfL232-L233)