### PR TITLE
Remove redundant checkout steps from CI and build action workflows

### DIFF
--- a/.github/actions/build/build-wheel/action.yml
+++ b/.github/actions/build/build-wheel/action.yml
@@ -4,7 +4,6 @@ description: Build Python wheel package and upload as artifact.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup/install-python-core
         if: github.event.repository.name == 'template-python'
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-core@main

--- a/.github/actions/build/verify-structure/action.yml
+++ b/.github/actions/build/verify-structure/action.yml
@@ -10,7 +10,6 @@ inputs:
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup/install-python-core
         if: github.event.repository.name == 'template-python'
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-core@main

--- a/.github/actions/ci/bandit/action.yml
+++ b/.github/actions/ci/bandit/action.yml
@@ -4,7 +4,6 @@ description: Run Bandit security checks on the codebase.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup/install-python-dev
         if: github.event.repository.name == 'template-python'
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main

--- a/.github/actions/ci/mypy/action.yml
+++ b/.github/actions/ci/mypy/action.yml
@@ -4,7 +4,6 @@ description: Run Mypy type checking on the codebase.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup/install-python-dev
         if: github.event.repository.name == 'template-python'
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main

--- a/.github/actions/ci/pip-audit/action.yml
+++ b/.github/actions/ci/pip-audit/action.yml
@@ -4,7 +4,6 @@ description: Run pip-audit to check for known vulnerabilities in dependencies.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup/install-python-dev
         if: github.event.repository.name == 'template-python'
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main

--- a/.github/actions/ci/pytest/action.yml
+++ b/.github/actions/ci/pytest/action.yml
@@ -4,7 +4,6 @@ description: Run Pytest tests with coverage reporting.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup/install-python-dev
         if: github.event.repository.name == 'template-python'
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main

--- a/.github/actions/ci/ruff/action.yml
+++ b/.github/actions/ci/ruff/action.yml
@@ -4,7 +4,6 @@ description: Run Ruff linting checks on the codebase.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup/install-python-dev
         if: github.event.repository.name == 'template-python'
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main

--- a/.github/actions/ci/validate-pyproject/action.yml
+++ b/.github/actions/ci/validate-pyproject/action.yml
@@ -4,7 +4,6 @@ description: Validate pyproject.toml structure.
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup/install-python-dev
         if: github.event.repository.name == 'template-python'
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main

--- a/.github/actions/ci/version-check/action.yml
+++ b/.github/actions/ci/version-check/action.yml
@@ -10,7 +10,6 @@ inputs:
 runs:
   using: composite
   steps:
-      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup/install-python-dev
         if: github.event.repository.name == 'template-python'
       - uses: javidahmed64592/template-python/.github/actions/setup/install-python-dev@main

--- a/.github/actions/setup/install-python-core/action.yml
+++ b/.github/actions/setup/install-python-core/action.yml
@@ -4,7 +4,6 @@ description: Installs core Python dependencies from pyproject.toml using uv.
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
     - uses: ./.github/actions/setup/setup-uv-python
       if: github.event.repository.name == 'template-python'
     - uses: javidahmed64592/template-python/.github/actions/setup/setup-uv-python@main

--- a/.github/actions/setup/install-python-dev/action.yml
+++ b/.github/actions/setup/install-python-dev/action.yml
@@ -4,7 +4,6 @@ description: Installs dev Python dependencies from pyproject.toml using uv.
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
     - uses: ./.github/actions/setup/setup-uv-python
       if: github.event.repository.name == 'template-python'
     - uses: javidahmed64592/template-python/.github/actions/setup/setup-uv-python@main


### PR DESCRIPTION
This pull request updates multiple GitHub Actions workflow files to remove the `actions/checkout@v6` step from each composite action. This change streamlines the setup process for CI and build workflows by relying on the repository context being checked out elsewhere, reducing redundancy across actions.

Workflow step removal:

* All composite actions in `.github/actions/build` and `.github/actions/ci` no longer include the `actions/checkout@v6` step, simplifying their execution and avoiding unnecessary repository checkouts. [[1]](diffhunk://#diff-f65ceb4aa896a48109c0f158a6dcea220f9ff876f878f9f4108e22d4363d10e3L7) [[2]](diffhunk://#diff-bd52ab90a0a08f216430880f6229c55c9cce1a60a5fd113c7bb08980a030748dL13) [[3]](diffhunk://#diff-7dd4679fbcd0361c01825a7581078219358278b1ba7c6e5871843e34d076e48cL7) [[4]](diffhunk://#diff-e839be1fb2c84ebde8f1cb88ffed3eb71510daa6fdb7cbff346fed18a4e3a0a9L7) [[5]](diffhunk://#diff-712f0fe4f82fa6245233e51f17e139a243230bf1fb773c95a2dbf991d1f2a861L7) [[6]](diffhunk://#diff-00ad0a661817fe7867276cf46198da0e94761a94060da856a057a7a432995cd9L7) [[7]](diffhunk://#diff-a2fc2029ef04a6348257eb8ae5e42b673171470cf0b6e98b6223c6f86afd7da3L7) [[8]](diffhunk://#diff-ae0e40b806ed62d8ee33315d8e967f02be265483820cf2807a7e2122b119c7e2L7) [[9]](diffhunk://#diff-f7e6e6268b0d81dc1741c1e5b4df691cf31c9f83c7386d26334f6b52be438fe8L13)

Setup actions update:

* The setup actions for installing core and dev Python dependencies (`install-python-core` and `install-python-dev`) also remove the `actions/checkout@v6` step, ensuring consistency across all custom composite actions. [[1]](diffhunk://#diff-bf0eb66e60adb3a2cf9c9070168ea1952d34385123f03e43a8474a4dc7d40cbbL7) [[2]](diffhunk://#diff-3f44307bf777f419b8da80c4aeb4e049b23f38a36a68c0b8af010eb9983f9201L7)