### PR TITLE
Uncomment action for installing Python docs in CI workflow

### DIFF
--- a/.github/actions/docs/build-docs/action.yml
+++ b/.github/actions/docs/build-docs/action.yml
@@ -6,8 +6,8 @@ runs:
   steps:
     - uses: ./.github/actions/setup/install-python-docs
       if: github.event.repository.name == 'template-python'
-    # - uses: javidahmed64592/template-python/.github/actions/setup/install-python-docs@main
-    #   if: github.event.repository.name != 'template-python'
+    - uses: javidahmed64592/template-python/.github/actions/setup/install-python-docs@main
+      if: github.event.repository.name != 'template-python'
 
     - name: Build docs
       run: |


### PR DESCRIPTION
This pull request updates the workflow configuration for building documentation. The main change is to enable the use of a shared GitHub Action for installing Python documentation dependencies when running outside the `template-python` repository.

Workflow improvements:

* [`.github/actions/docs/build-docs/action.yml`](diffhunk://#diff-4b637e3b8058499590b9e6a6cc6425cbdd7478bc0ca32eb4d371c78b2b145d4fL9-R10): Uncommented and enabled the use of the shared `install-python-docs` action from the `javidahmed64592/template-python` repository for repositories other than `template-python`.