### PR TITLE
Enhance sphinx setup

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,9 +8,11 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from template_python.constants import SPHINX_EXTENSIONS, SPHINX_HTML_THEME
 from template_python.workflows import (
     get_author_from_pyproject,
     get_name_from_pyproject,
+    get_rst_prolog,
     get_version_from_pyproject,
 )
 
@@ -29,14 +31,7 @@ package_name = get_name_from_pyproject().replace("-", "_")
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = [
-    "sphinx.ext.autodoc",  # Auto-generate API docs from docstrings
-    "sphinx.ext.autosummary",  # Generate summary tables
-    "sphinx.ext.napoleon",  # Support Google/NumPy style docstrings
-    "sphinx.ext.viewcode",  # Add links to highlighted source code
-    "sphinx.ext.intersphinx",  # Link to other project documentation
-    "sphinx_autodoc_typehints",  # Better type hint rendering
-]
+extensions = SPHINX_EXTENSIONS
 
 # Napoleon settings for Google-style docstrings
 napoleon_google_docstring = True
@@ -78,12 +73,12 @@ exclude_patterns: list[str] = []
 # -- RST substitutions -------------------------------------------------------
 # These variables are automatically available in all RST files as |variable_name|
 
-rst_prolog = f"""
-.. |project_name| replace:: {project}
-.. |package_name| replace:: {package_name}
-"""
+rst_prolog = get_rst_prolog(
+    keys=["project_name", "package_name"],
+    values=[project, package_name],
+)
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "furo"
+html_theme = SPHINX_HTML_THEME

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,6 +73,7 @@ exclude_patterns: list[str] = []
 # -- RST substitutions -------------------------------------------------------
 # These variables are automatically available in all RST files as |variable_name|
 
+substitutions_default_enabled = True
 rst_prolog = get_rst_prolog(
     keys=["project_name", "package_name"],
     values=[project, package_name],

--- a/docs/source/smg.rst
+++ b/docs/source/smg.rst
@@ -1,7 +1,7 @@
 Software Maintenance Guide
 ===========================
 
-This document outlines how to configure and setup a development environment to work on this Python application.
+This document outlines how to configure and setup a development environment to work on this codebase.
 
 Backend (Python)
 ----------------
@@ -48,10 +48,25 @@ To include extra dependencies:
 Testing, Linting, and Type Checking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Lint code:** ``uv run ruff check .``
-- **Format code:** ``uv run ruff format .``
-- **Type check:** ``uv run mypy .``
-- **Run tests:** ``uv run pytest``
+.. code-block:: sh
+
+   # Lint code
+   uv run ruff check .
+
+   # Format code
+   uv run ruff format .
+
+   # Type check
+   uv run mypy .
+
+   # Run tests
+   uv run pytest
+
+   # Security scan
+   uv run bandit -r |package_name|/
+
+   # Audit dependencies
+   uv run pip-audit
 
 Building Documentation
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ docs = [
     "linkify-it-py>=2.1.0",
     "sphinx>=9.1.0",
     "sphinx-autodoc-typehints>=3.10.0",
+    "sphinx-substitution-extensions>=2026.1.12",
 ]
 
 [project.urls]

--- a/template_python/constants.py
+++ b/template_python/constants.py
@@ -1,0 +1,12 @@
+"""Constants for codebases using this template."""
+
+# Sphinx
+SPHINX_EXTENSIONS = [
+    "sphinx.ext.autodoc",  # Auto-generate API docs from docstrings
+    "sphinx.ext.autosummary",  # Generate summary tables
+    "sphinx.ext.napoleon",  # Support Google/NumPy style docstrings
+    "sphinx.ext.viewcode",  # Add links to highlighted source code
+    "sphinx.ext.intersphinx",  # Link to other project documentation
+    "sphinx_autodoc_typehints",  # Better type hint rendering
+]
+SPHINX_HTML_THEME = "furo"

--- a/template_python/constants.py
+++ b/template_python/constants.py
@@ -8,5 +8,6 @@ SPHINX_EXTENSIONS = [
     "sphinx.ext.viewcode",  # Add links to highlighted source code
     "sphinx.ext.intersphinx",  # Link to other project documentation
     "sphinx_autodoc_typehints",  # Better type hint rendering
+    "sphinx_substitution_extensions",  # Support for substitutions in RST files
 ]
 SPHINX_HTML_THEME = "furo"

--- a/template_python/workflows.py
+++ b/template_python/workflows.py
@@ -57,6 +57,14 @@ def get_version_from_uv_lock() -> str:
     raise ValueError(error_msg)
 
 
+def get_rst_prolog(keys: list[str], values: list[str]) -> str:
+    """Generate an RST prolog with the given keys and values."""
+    if len(keys) != len(values):
+        error_msg = "Keys and values must have the same length."
+        raise ValueError(error_msg)
+    return "\n".join(f".. |{k}| replace:: {v}" for k, v in zip(keys, values, strict=False))
+
+
 def print_version_pyproject() -> None:
     """Run `ci-pyproject-version` to echo the version from `pyproject.toml`."""
     print(get_version_from_pyproject())

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -9,6 +9,7 @@ from template_python.workflows import (
     _load_uv_lock,
     get_author_from_pyproject,
     get_name_from_pyproject,
+    get_rst_prolog,
     get_version_from_pyproject,
     get_version_from_uv_lock,
     print_name_pyproject,
@@ -73,6 +74,14 @@ class TestWorkflows:
             pytest.raises(ValueError, match=rf"Package '{pyproject['project']['name']}' not found in `uv.lock`"),
         ):
             get_version_from_uv_lock()
+
+    def test_get_rst_prolog(self) -> None:
+        """Test generating an RST prolog."""
+        keys = ["key1", "key2"]
+        values = ["value1", "value2"]
+        prolog = get_rst_prolog(keys, values)
+        expected_prolog = ".. |key1| replace:: value1\n.. |key2| replace:: value2"
+        assert prolog == expected_prolog
 
     def test_print_version_pyproject(self) -> None:
         """Test printing the version from `pyproject.toml`."""

--- a/uv.lock
+++ b/uv.lock
@@ -48,6 +48,15 @@ wheels = [
 ]
 
 [[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -473,6 +482,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -559,6 +580,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl", hash = "sha256:ab31e516024918296e169139072b81592336f2fef55b8986aa31c9f04b5f7211", size = 84533, upload-time = "2026-01-15T09:08:16.788Z" },
 ]
 
 [[package]]
@@ -908,6 +946,21 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-substitution-extensions"
+version = "2026.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "docutils" },
+    { name = "myst-parser" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/3e/a82aa5fed0d06161a89dc2f6971b160f837cad44f196c467fc6b2132acaa/sphinx_substitution_extensions-2026.1.12.tar.gz", hash = "sha256:25e0c6c40fbf9e1df593883da946879044a3bf8d85652c8c58f354a53575d736", size = 31676, upload-time = "2026-01-12T06:19:35.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/5e/9caa7167d2ef2b60326765150d64513be1b61b1864ad58a92683578b2776/sphinx_substitution_extensions-2026.1.12-py2.py3-none-any.whl", hash = "sha256:9152beb4f0f5cab52057681b376a473fa6b997defc85d4ac154dd12b13a3e987", size = 8766, upload-time = "2026-01-12T06:19:33.541Z" },
+]
+
+[[package]]
 name = "sphinxcontrib-applehelp"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -993,6 +1046,7 @@ docs = [
     { name = "linkify-it-py" },
     { name = "sphinx" },
     { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-substitution-extensions" },
 ]
 
 [package.metadata]
@@ -1008,6 +1062,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.10" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=9.1.0" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=3.10.0" },
+    { name = "sphinx-substitution-extensions", marker = "extra == 'docs'", specifier = ">=2026.1.12" },
     { name = "validate-pyproject", marker = "extra == 'dev'", specifier = ">=0.25.0" },
 ]
 provides-extras = ["dev", "docs"]


### PR DESCRIPTION
This pull request improves the Sphinx documentation configuration by centralizing Sphinx-related settings and constants, enhancing maintainability, and expanding documentation tooling. It also updates the Software Maintenance Guide with clearer instructions and adds new tests for documentation utilities.

**Documentation configuration improvements:**

* Centralized Sphinx extension and theme configuration by moving them to `SPHINX_EXTENSIONS` and `SPHINX_HTML_THEME` constants in `template_python/constants.py`, and updating `docs/source/conf.py` to use these constants. This makes it easier to update Sphinx settings in one place. [[1]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698R11-R15) [[2]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698L32-R34) [[3]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698L81-R85) [[4]](diffhunk://#diff-ce30b3e6fb7e3d01b6d71bb0807d0ecc172e122e927781e79d4f486cf75d6784R1-R13)
* Added the `sphinx-substitution-extensions` package to the documentation dependencies in `pyproject.toml` to support more flexible RST substitutions.

**Documentation utilities and testing:**

* Introduced a new utility function `get_rst_prolog` in `template_python/workflows.py` to generate RST prolog substitutions programmatically, and updated `conf.py` to use this function for RST variable substitution. Added corresponding unit test in `tests/test_workflows.py`. [[1]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698R11-R15) [[2]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698L81-R85) [[3]](diffhunk://#diff-ea6ec9d30bd039a01ba224b519cd5fb4027e7dcdaa6a4581d635a4bbbc06e79dR60-R67) [[4]](diffhunk://#diff-062d7920c867ef17e231797ab56a990f96a5beafa69c52c03fee3f19f7b19cccR12) [[5]](diffhunk://#diff-062d7920c867ef17e231797ab56a990f96a5beafa69c52c03fee3f19f7b19cccR78-R85)

**Software Maintenance Guide improvements:**

* Updated the Software Maintenance Guide (`docs/source/smg.rst`) to clarify that it applies to the whole codebase and improved the formatting of testing, linting, and security/audit instructions by using a shell code block and adding commands for security scanning and dependency auditing. [[1]](diffhunk://#diff-48a306368902a6f65e4cfc74f1b5e38e71486a687d7aab69b960945ddaea571eL4-R4) [[2]](diffhunk://#diff-48a306368902a6f65e4cfc74f1b5e38e71486a687d7aab69b960945ddaea571eL51-R69)