### PR TITLE
Add .gitattributes file to manage line endings and binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Set default behavior to automatically normalize line endings
+* text=auto
+
+# Convert to LF line endings for specific text file types
+*.py text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.txt text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary


### PR DESCRIPTION
This pull request adds a `.gitattributes` file to the repository to standardize line endings and properly handle binary files. This helps prevent issues with inconsistent line endings across different operating systems and ensures binary files are not corrupted by Git.

Repository configuration improvements:

* Added a `.gitattributes` file that enforces automatic normalization of line endings for text files and specifies LF endings for common code and configuration file types.
* Marked common binary file types (such as images and fonts) to be treated as binary by Git, preventing line ending conversion or corruption.