### PR TITLE
Add frontend-dir-exists parameter to build and CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: javidahmed64592/actions-template-python/actions/build/verify-structure@main
+        with:
+          frontend-dir-exists: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: javidahmed64592/actions-template-python/actions/ci/version-check@main
+        with:
+          frontend-dir-exists: false
 
   frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to clarify that there is no frontend directory in the project. The main change is the addition of the `frontend-dir-exists: false` parameter to relevant workflow steps.

Workflow configuration updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R24-R25): Added `frontend-dir-exists: false` to the `verify-structure` step to indicate the absence of a frontend directory.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR57-R58): Added `frontend-dir-exists: false` to the `version-check` step for the same purpose.